### PR TITLE
Retrieve SO based on Role

### DIFF
--- a/src/main/java/com/cognizant/trms/model/user/Team.java
+++ b/src/main/java/com/cognizant/trms/model/user/Team.java
@@ -78,4 +78,5 @@ public class Team {
 	 * 
 	 * @LastModifiedDate private Date lastModifiedDate;
 	 */
+
 }

--- a/src/main/java/com/cognizant/trms/repository/opportunity/SORepository.java
+++ b/src/main/java/com/cognizant/trms/repository/opportunity/SORepository.java
@@ -2,7 +2,7 @@ package com.cognizant.trms.repository.opportunity;
 
 import com.cognizant.trms.model.opportunity.SO;
 
-import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
@@ -11,9 +11,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 */
 public interface SORepository extends MongoRepository<SO, String> {
 
-
     SO findByServiceOrder(String so);
-    List<SO> findByCreatedBy(String createdBy);
-
-
+    Set<SO> findByCreatedBy(String createdBy);
+    Set<SO> findByTeamId(String teamId);
 }

--- a/src/main/java/com/cognizant/trms/repository/user/UserRoleRepository.java
+++ b/src/main/java/com/cognizant/trms/repository/user/UserRoleRepository.java
@@ -16,8 +16,12 @@ public interface UserRoleRepository extends MongoRepository<UserRole, String> {
 	UserRole findByUserIdAndRoleIdAndAccount(String userId, String roleId, Account account);
 
 	UserRole findByRoleIdAndAccountAndProgram(String roleId, Account account, Program program);
+	
+	UserRole findByRoleIdAndAccountAndProgramAndTeam(String roleId, Account account, Program program,Team team);
 
 	UserRole findByUserIdAndRoleIdAndAccountAndProgram(String userId, String roleId, Account account, Program program);
+	
+	UserRole findByUserIdAndRoleIdAndAccountAndProgramAndTeam(String userId, String roleId, Account account, Program program,Team team);
 
 	List<UserRole> findByAccount(Account account);
 
@@ -26,4 +30,10 @@ public interface UserRoleRepository extends MongoRepository<UserRole, String> {
 	List<UserRole> findByTeam(Team team);
 
 	List<UserRole> findByUser(User user);
+	
+	List<UserRole> findAccountByUser(User user);
+	
+	List<UserRole> findProgramByUser(User user);
+	
+
 }

--- a/src/main/java/com/cognizant/trms/service/ProgramServiceImpl.java
+++ b/src/main/java/com/cognizant/trms/service/ProgramServiceImpl.java
@@ -7,8 +7,7 @@ import java.util.Set;
 
 import com.cognizant.trms.dto.model.user.ProgramDto;
 
-import java.util.Arrays;
-import java.util.HashSet;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.TreeSet;
@@ -214,7 +213,7 @@ public class ProgramServiceImpl implements ProgramService {
 		userRoleRepository.save(userRole);
 
 		//user.setRoles(new HashSet<>(Arrays.asList(role)));
-		userRepository.save(user);
+		//userRepository.save(user);
 	}
 
 	/**
@@ -235,7 +234,7 @@ public class ProgramServiceImpl implements ProgramService {
 			existingUserRole.setUser(user);
 			userRoleRepository.save(existingUserRole);
 			//user.setRoles(new HashSet<>(Arrays.asList(role)));
-			userRepository.save(user);
+			//userRepository.save(user);
 		}
 
 	}

--- a/src/main/java/com/cognizant/trms/service/SOService.java
+++ b/src/main/java/com/cognizant/trms/service/SOService.java
@@ -11,11 +11,12 @@ import com.cognizant.trms.dto.model.opportunity.SODto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
+import java.util.Set;
 
 public interface SOService {
 	SODto createSO(SOCreateRequest soCreateRequest) throws JsonProcessingException;
 
-	List<SODto> getSOByLoginUser() throws JsonProcessingException;
+	Set<SODto> getSOByLoginUser() throws JsonProcessingException;
 
 	SODto getCasesBySO(String soId) throws JsonProcessingException;
 

--- a/src/main/java/com/cognizant/trms/service/UserService.java
+++ b/src/main/java/com/cognizant/trms/service/UserService.java
@@ -1,12 +1,12 @@
 package com.cognizant.trms.service;
 
 import com.cognizant.trms.controller.v1.request.UserProfileRequest;
-import com.cognizant.trms.controller.v1.request.UserSignupRequest;
+
 import com.cognizant.trms.dto.model.user.UserDto;
-import com.cognizant.trms.dto.model.user.UserRoleDto;
 import com.cognizant.trms.dto.model.user.UserRoleDtoMinimal;
+
 import com.cognizant.trms.model.user.User;
-import com.cognizant.trms.model.user.UserRole;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
@@ -55,4 +55,5 @@ public interface UserService {
     List<UserRoleDtoMinimal> getUserByProgram(String programId);
     List<UserRoleDtoMinimal> getUserByTeam(String teamId);
     List<String> getUserRoleByUser(User user);
+    
 }

--- a/src/main/java/com/cognizant/trms/service/UserServiceImpl.java
+++ b/src/main/java/com/cognizant/trms/service/UserServiceImpl.java
@@ -250,4 +250,6 @@ public class UserServiceImpl implements UserService {
     private RuntimeException exceptionWithId(EntityType entityType, ExceptionType exceptionType, String id, String... args) {
         return TRMSException.throwExceptionWithId(entityType, exceptionType, id, args);
     }
+
+
 }


### PR DESCRIPTION
Hi Aravind,

a) SORepository -> Modified List to Set on SO retrieval 
b) UserRoleRepository -> 
           i) While the creation of Program and Team, UserRole object insertion is required.  Pulled earlier logic again.
           ii) Added new methods to retrieve a list of teams based on Account, Program. To retrieve accounts based on User.

c) ProgramServiceImpl -> Create and update user role methods. UserRole object alone will be inserted/updated here. No changes to the user objects.

d) SOService -> List to Set modification

e) SOServiceServiceImpl -> Modified getSOByLoginUser() method. Now SO's will retrieve based on users roles.

f)  TeamServiceImpl -> Create and update user role methods. UserRole object alone will be inserted/updated here. No changes to the user objects.

g) Not many changes for the below. Looks Alignment changes or removed on unused imports.
   - Team.java
 - UserService.java
 - UserServiceImpl.java